### PR TITLE
copy-slice and concat-bytes added to bytes ns

### DIFF
--- a/src/alphabase/bytes.cljc
+++ b/src/alphabase/bytes.cljc
@@ -138,3 +138,28 @@
             (- ai bi)))
         ; Reached the end of the shorter key, compare lengths.
         (- (alength a) (alength b))))))
+
+
+(defn copy-slice
+  "Copy a slice (defined by offset, length) from a byte array.
+
+  Omitting the slice `len` argument will copy remainder of
+  `src` array from offset (e.g, `(- (alength src) offset)` bytes)."
+  (^bytes [^bytes src offset len]
+   (let [dst (byte-array len)]
+     (copy src offset dst 0 len)
+     dst))
+  (^bytes [src offset]
+   (copy-slice src offset (- (alength ^bytes src) offset))))
+
+
+(defn concat-bytes
+  "Concatenate bytes arrays into a single new byte array."
+  [& arrs]
+  (let [total-len (reduce + (map #(alength ^bytes %) arrs))
+        dst (byte-array total-len)]
+    (loop [arrs arrs offset 0]
+      (when-let [src (first arrs)]
+        (copy src 0 dst offset (alength ^bytes src))
+        (recur (rest arrs) (+ offset (alength src)))))
+    dst))

--- a/src/alphabase/bytes.cljc
+++ b/src/alphabase/bytes.cljc
@@ -1,6 +1,6 @@
 (ns alphabase.bytes
   "Functions to generically handle byte arrays."
-  (:refer-clojure :exclude [bytes? byte-array compare]))
+  (:refer-clojure :exclude [bytes? byte-array compare concat]))
 
 
 (defn to-byte
@@ -153,7 +153,7 @@
    (copy-slice src offset (- (alength ^bytes src) offset))))
 
 
-(defn concat-bytes
+(defn concat
   "Concatenate bytes arrays into a single new byte array."
   [& arrs]
   (let [total-len (reduce + (map #(alength ^bytes %) arrs))

--- a/test/alphabase/bytes_test.cljc
+++ b/test/alphabase/bytes_test.cljc
@@ -92,7 +92,7 @@
 (deftest concat-arrs
   (are [arrs expected]
     (b/bytes= (b/init-bytes expected)
-              (->> arrs (map b/init-bytes) (apply b/concat-bytes)))
+              (->> arrs (map b/init-bytes) (apply b/concat)))
     [[0 1] [2 3] [3 4]] [0 1 2 3 3 4]
     [[0 1]] [0 1]
     [[0 1] [0 1 2]] [0 1 0 1 2]

--- a/test/alphabase/bytes_test.cljc
+++ b/test/alphabase/bytes_test.cljc
@@ -1,7 +1,7 @@
 (ns alphabase.bytes-test
   (:require
     #?(:clj [clojure.test :refer :all]
-       :cljs [cljs.test :refer-macros [deftest is testing]])
+       :cljs [cljs.test :refer-macros [deftest is are testing]])
     [alphabase.bytes :as b]))
 
 
@@ -71,3 +71,29 @@
   (is (neg? (b/compare
               (b/init-bytes [0 1 2 0])
               (b/init-bytes [0 1 2 0 0])))))
+
+(deftest copy-slice
+  (are [bs offset len]
+    (b/bytes= (b/init-bytes (take len (drop offset bs)))
+             (-> bs b/init-bytes (b/copy-slice offset len)))
+    [1 2 3 4 5 6 7 8 9 10] 5 3
+    [0 1 2 0] 0 2
+    [0 1 2 0] 0 0
+    [0 1 2 0] 2 1)
+  (are [bs offset]
+      (= (drop offset bs)
+         (-> bs b/init-bytes (b/copy-slice offset) b/byte-seq))
+    [1 2 3 4 5 6 7 8 9 10] 5
+    [0 1 2 0] 0
+    [0 1 2 0] 0
+    [0 1 2 0] 2))
+
+
+(deftest concat-arrs
+  (are [arrs expected]
+    (b/bytes= (b/init-bytes expected)
+              (->> arrs (map b/init-bytes) (apply b/concat-bytes)))
+    [[0 1] [2 3] [3 4]] [0 1 2 3 3 4]
+    [[0 1]] [0 1]
+    [[0 1] [0 1 2]] [0 1 0 1 2]
+    [[]] []))


### PR DESCRIPTION
Added utilities used in [`clj-multiformat` pr](https://github.com/greglook/clj-multiformats/pulls)

* `copy-slice`: Handle frequent need to copy a slice of array without creating empty destination array first
* `concat-bytes`: Handle frequent need to take different byte arrays and concatenate efficiently without boxing 